### PR TITLE
Specify numpy version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.20
 scipy
 # backports.strenum; python_version < '3.10'
 


### PR DESCRIPTION
Hi @clbarnes! 

I had an issue importing navis (which imports this) which I tracked down to `numpy.typing` not being available before 1.20.0 [(changelog)](https://numpy.org/devdocs/release/1.20.0-notes.html#numpy-typing-is-accessible-at-runtime) and the import [here](https://github.com/clbarnes/molesq/blob/297c08dc0a41390dda5e8e5fc1bda612d7c417c0/molesq/transform.py#L6).

Thought it'd be good to specify this explicitly, which should also resolve this upstream in navis. 